### PR TITLE
feat(navigation): add sidebar links and pages

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,5 +1,7 @@
 // file: src/app/(dashboard)/layout.tsx
 import React from "react";
+import Link from "next/link";
+import { Home, UserPlus, Users } from "lucide-react";
 import { ModeToggle } from "@/components/mode-toggle";
 
 export default function DashboardLayout({
@@ -11,10 +13,39 @@ export default function DashboardLayout({
     <div className="flex min-h-screen w-full flex-col bg-muted/40">
       {/* Sidebar */}
       <aside className="fixed inset-y-0 left-0 z-10 hidden w-60 flex-col border-r bg-background sm:flex">
-        <nav className="flex flex-col items-center gap-4 px-2 sm:py-5">
-          <h1 className="text-2xl font-bold text-primary">Echostatus</h1>
-          {/* Sidebar navigation links will go here */}
-        </nav>
+        <div className="flex h-full max-h-screen flex-col gap-2">
+          <div className="flex h-14 items-center border-b px-4 lg:h-[60px] lg:px-6">
+            <Link
+              href="/"
+              className="flex items-center gap-2 font-semibold text-primary"
+            >
+              <span className="text-xl font-bold">Echostatus</span>
+            </Link>
+          </div>
+          <nav className="flex-1 grid items-start px-2 text-sm font-medium lg:px-4">
+            <Link
+              href="/"
+              className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-primary"
+            >
+              <Home className="h-4 w-4" />
+              Home
+            </Link>
+            <Link
+              href="/users"
+              className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-primary"
+            >
+              <Users className="h-4 w-4" />
+              User List
+            </Link>
+            <Link
+              href="/users/create"
+              className="flex items-center gap-3 rounded-lg px-3 py-2 text-muted-foreground transition-all hover:text-primary"
+            >
+              <UserPlus className="h-4 w-4" />
+              Create User
+            </Link>
+          </nav>
+        </div>
       </aside>
 
       {/* Main Content Area */}

--- a/src/app/(dashboard)/users/create/page.tsx
+++ b/src/app/(dashboard)/users/create/page.tsx
@@ -1,0 +1,15 @@
+// file: src/app/(dashboard)/users/create/page.tsx
+export default function CreateUserPage() {
+  return (
+    <main className="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8">
+      <div className="rounded-xl border bg-card text-card-foreground shadow">
+        <div className="p-6">
+          <h2 className="text-3xl font-bold tracking-tight">Create User</h2>
+          <p className="mt-2 text-muted-foreground">
+            A form to create a new user will be displayed here.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -1,0 +1,15 @@
+// file: src/app/(dashboard)/users/page.tsx
+export default function UserListPage() {
+  return (
+    <main className="grid flex-1 items-start gap-4 p-4 sm:px-6 sm:py-0 md:gap-8">
+      <div className="rounded-xl border bg-card text-card-foreground shadow">
+        <div className="p-6">
+          <h2 className="text-3xl font-bold tracking-tight">User List</h2>
+          <p className="mt-2 text-muted-foreground">
+            A list of all users will be displayed here.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}


### PR DESCRIPTION
### Description

This pull request implements the primary sidebar navigation for the application. It adds links for "Home", "User List", and "Create User" and creates the corresponding placeholder pages to make the application navigable.

### Key Changes

*   **Dashboard Layout (`src/app/(dashboard)/layout.tsx`)**:
    *   Updated the sidebar to include `next/link` components for navigation.
    *   Added `Home`, `Users`, and `UserPlus` icons from `lucide-react` to enhance the UI.
    *   Restructured the sidebar HTML for better organization (logo area and nav area).

*   **User List Page (`src/app/(dashboard)/users/page.tsx`)**:
    *   Created a new page at the `/users` route.
    *   Added placeholder content to confirm navigation is successful.

*   **Create User Page (`src/app/(dashboard)/users/create/page.tsx`)**:
    *   Created a new page at the `/users/create` route.
    *   Added placeholder content to confirm navigation is successful.

### How to Test

1.  Pull down this branch locally.
2.  Run `npm run dev`.
3.  Open the application at `http://localhost:3000`.
4.  **Verify the following:**
    *   The sidebar on the left should now contain three clickable links: "Home", "User List", and "Create User", each with an icon.
    *   Clicking "Home" should navigate to the main welcome page.
    *   Clicking "User List" should navigate to the `/users` page, showing the "User List" placeholder.
    *   Clicking "Create User" should navigate to the `/users/create` page, showing the "Create User" placeholder.
    *   All navigation should happen without a page reload and with no 404 errors.