### PR TITLE
feat(notes): add past notes widget and dynamic header

### DIFF
--- a/src/app/(dashboard)/layout.tsx
+++ b/src/app/(dashboard)/layout.tsx
@@ -1,9 +1,8 @@
 // file: src/app/(dashboard)/layout.tsx
 import React, { Suspense } from "react";
 import Link from "next/link";
-import { ModeToggle } from "@/components/mode-toggle";
-import { UserSwitcher } from "@/components/user-switcher";
 import { NavLinks } from "@/components/nav-links";
+import { DashboardHeader } from "@/components/dashboard-header";
 
 export default function DashboardLayout({
   children,
@@ -35,20 +34,7 @@ export default function DashboardLayout({
 
       {/* Main Content Area */}
       <div className="flex flex-col sm:gap-4 sm:py-4 sm:pl-60">
-        {/* Header */}
-        <header className="sticky top-0 z-30 flex h-14 items-center justify-between gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
-          <div className="font-semibold">
-            {/* Page title will go here */}
-            Home
-          </div>
-          <div className="flex items-center gap-4">
-            <Suspense fallback={<div>Loading...</div>}>
-              <UserSwitcher />
-            </Suspense>
-            <ModeToggle />
-          </div>
-        </header>
-
+        <DashboardHeader />
         {/* Page Content */}
         {children}
       </div>

--- a/src/app/(dashboard)/standup-notes/actions.ts
+++ b/src/app/(dashboard)/standup-notes/actions.ts
@@ -1,7 +1,7 @@
 // file: src/app/(dashboard)/standup-notes/actions.ts
 "use server";
 
-import { createSupabaseServerClientReadOnly } from "@/lib/supabase/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 
 type FormState = {
@@ -13,7 +13,7 @@ export async function saveNote(
   prevState: FormState,
   formData: FormData
 ): Promise<FormState> {
-  const supabase = createSupabaseServerClientReadOnly();
+  const supabase = createSupabaseServerClient();
 
   const yesterdayText = formData.get("yesterday_text") as string;
   const todayText = formData.get("today_text") as string;

--- a/src/app/(dashboard)/standup-notes/components/past-notes-list.tsx
+++ b/src/app/(dashboard)/standup-notes/components/past-notes-list.tsx
@@ -1,0 +1,138 @@
+// file: src/app/(dashboard)/standup-notes/components/past-notes-list.tsx
+"use client";
+
+import { useState, useEffect } from "react";
+import { createSupabaseClient } from "@/lib/supabase/client";
+import { Separator } from "@/components/ui/separator";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface PastNotesListProps {
+  userId: string;
+  refreshKey: number;
+}
+
+type Note = {
+  date: string;
+  yesterday_text: string | null;
+  today_text: string | null;
+  blockers_text: string | null;
+  learnings_text: string | null;
+};
+
+export function PastNotesList({ userId, refreshKey }: PastNotesListProps) {
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchPastNotes = async () => {
+      setLoading(true);
+      const supabase = createSupabaseClient();
+      const { data, error } = await supabase
+        .from("notes")
+        .select(
+          "date, yesterday_text, today_text, blockers_text, learnings_text"
+        )
+        .eq("user_id", userId)
+        .order("date", { ascending: false });
+
+      if (error) {
+        console.error("Error fetching past notes:", error);
+      } else {
+        setNotes(data || []);
+      }
+      setLoading(false);
+    };
+
+    if (userId) {
+      fetchPastNotes();
+    }
+  }, [userId, refreshKey]);
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border bg-card text-card-foreground shadow-sm">
+        <div className="flex flex-col space-y-1.5 p-6 bg-muted/50 border-b">
+          <Skeleton className="h-7 w-1/2" />
+          <Skeleton className="h-4 w-3/4" />
+        </div>
+        <div className="p-6 space-y-4">
+          <Skeleton className="h-24 w-full" />
+          <Skeleton className="h-24 w-full" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border bg-card text-card-foreground shadow-sm">
+      <div className="flex flex-col space-y-1.5 p-6 bg-muted/50 border-b">
+        <h3 className="text-2xl font-semibold leading-none tracking-tight">
+          Past Notes
+        </h3>
+        <p className="text-sm text-muted-foreground">
+          A history of your previous standup notes.
+        </p>
+      </div>
+      <div className="p-6">
+        <div className="space-y-4 max-h-[600px] overflow-y-auto pr-4">
+          {notes.length === 0 ? (
+            <p className="text-muted-foreground">No past notes found.</p>
+          ) : (
+            notes.map((note, index) => (
+              <div key={note.date} className="p-4 rounded-md even:bg-muted/50">
+                <h3 className="font-semibold text-lg">
+                  {new Date(note.date).toLocaleDateString("en-US", {
+                    year: "numeric",
+                    month: "long",
+                    day: "numeric",
+                    timeZone: "UTC",
+                  })}
+                </h3>
+                <div className="pl-4 text-sm space-y-2 mt-2">
+                  {note.yesterday_text && (
+                    <div>
+                      <p className="font-medium text-muted-foreground">
+                        Yesterday:
+                      </p>
+                      <p className="whitespace-pre-wrap">
+                        {note.yesterday_text}
+                      </p>
+                    </div>
+                  )}
+                  {note.today_text && (
+                    <div>
+                      <p className="font-medium text-muted-foreground">
+                        Today:
+                      </p>
+                      <p className="whitespace-pre-wrap">{note.today_text}</p>
+                    </div>
+                  )}
+                  {note.blockers_text && (
+                    <div>
+                      <p className="font-medium text-muted-foreground">
+                        Blocker(s):
+                      </p>
+                      <p className="whitespace-pre-wrap">
+                        {note.blockers_text}
+                      </p>
+                    </div>
+                  )}
+                  {note.learnings_text && (
+                    <div>
+                      <p className="font-medium text-muted-foreground">
+                        Learning(s):
+                      </p>
+                      <p className="whitespace-pre-wrap">
+                        {note.learnings_text}
+                      </p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/(dashboard)/standup-notes/page.tsx
+++ b/src/app/(dashboard)/standup-notes/page.tsx
@@ -2,10 +2,9 @@
 import { Suspense } from "react";
 import { StandupNotesView } from "./components/standup-notes-view";
 
-// This page is now a completely static shell. It knows nothing about searchParams.
 export default function StandupNotesPage() {
   return (
-    <Suspense fallback={<p className="p-4">Loading page...</p>}>
+    <Suspense fallback={<p className="p-4">Loading...</p>}>
       <StandupNotesView />
     </Suspense>
   );

--- a/src/app/(dashboard)/users/actions.ts
+++ b/src/app/(dashboard)/users/actions.ts
@@ -1,13 +1,13 @@
 // file: src/app/(dashboard)/users/actions.ts
 "use server";
 
-import { createSupabaseServerClientReadOnly } from "@/lib/supabase/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { revalidatePath } from "next/cache";
 import { redirect } from "next/navigation";
 
 export async function createUser(formData: FormData) {
   // Use the read-only client to avoid cookie-related errors for this public action
-  const supabase = createSupabaseServerClientReadOnly();
+  const supabase = createSupabaseServerClient();
 
   const githubUsername = formData.get("github-username") as string;
 

--- a/src/app/(dashboard)/users/page.tsx
+++ b/src/app/(dashboard)/users/page.tsx
@@ -1,6 +1,6 @@
 // file: src/app/(dashboard)/users/page.tsx
 import Link from "next/link";
-import { createSupabaseServerClientReadOnly } from "@/lib/supabase/server";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
 import { UserCard, type User } from "@/components/user-card";
 
 // Helper function to group users by team
@@ -16,7 +16,7 @@ function groupUsersByTeam(users: User[]): Record<string, User[]> {
 }
 
 export default async function UserListPage() {
-  const supabase = createSupabaseServerClientReadOnly();
+  const supabase = createSupabaseServerClient();
   const { data: users, error } = await supabase
     .from("users")
     .select("id, display_name, username, team, role")

--- a/src/components/dashboard-header.tsx
+++ b/src/components/dashboard-header.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { Suspense } from "react";
+import { usePathname } from "next/navigation";
+import { ModeToggle } from "@/components/mode-toggle";
+import { UserSwitcher } from "@/components/user-switcher";
+
+// A mapping from URL paths to friendly display names
+const pathNameMap: { [key: string]: string } = {
+  "/": "Home",
+  "/users": "User List",
+  "/users/create": "Create User",
+  "/standup-notes": "Standup Notes",
+  "/github-prs": "GitHub PRs",
+  "/edit-profile": "Edit Profile",
+};
+
+export function DashboardHeader() {
+  const pathname = usePathname();
+
+  // Look up the friendly name, or default to the capitalized path
+  const pageTitle =
+    pathNameMap[pathname] ||
+    pathname.split("/").pop()?.replace(/-/g, " ") ||
+    "Dashboard";
+
+  return (
+    <header className="sticky top-0 z-30 flex h-14 items-center justify-between gap-4 border-b bg-background px-4 sm:static sm:h-auto sm:border-0 sm:bg-transparent sm:px-6">
+      <div className="font-semibold capitalize">{pageTitle}</div>
+      <div className="flex items-center gap-4">
+        <Suspense fallback={<div>Loading...</div>}>
+          <UserSwitcher />
+        </Suspense>
+        <ModeToggle />
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn("bg-accent animate-pulse rounded-md", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/src/lib/supabase/actions.ts
+++ b/src/lib/supabase/actions.ts
@@ -1,0 +1,35 @@
+// file: src/lib/supabase/actions.ts
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+// This client is for server-side actions where you need to be logged in.
+// It uses server-only features and should only be imported in server actions.
+export function createSupabaseActionsClient() {
+  const cookieStore = cookies();
+
+  return createServerClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    {
+      cookies: {
+        get(name: string) {
+          return cookieStore.get(name)?.value;
+        },
+        set(name: string, value: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value, ...options });
+          } catch (error) {
+            // Ignored
+          }
+        },
+        remove(name: string, options: CookieOptions) {
+          try {
+            cookieStore.set({ name, value: "", ...options });
+          } catch (error) {
+            // Ignored
+          }
+        },
+      },
+    }
+  );
+}

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,53 +1,13 @@
 // file: src/lib/supabase/server.ts
-import {
-  createServerClient as _createServerClient,
-  type CookieOptions,
-} from "@supabase/ssr";
 import { createClient } from "@supabase/supabase-js";
-import { cookies } from "next/headers";
-
-// This client is for server-side actions where you need to be logged in.
-// It will be used for things like creating notes, updating profiles, etc.
-export function createSupabaseServerClient() {
-  const cookieStore = cookies();
-
-  return _createServerClient(
-    process.env.NEXT_PUBLIC_SUPABASE_URL!,
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
-    {
-      cookies: {
-        get(name: string) {
-          return cookieStore.get(name)?.value;
-        },
-        set(name: string, value: string, options: CookieOptions) {
-          try {
-            cookieStore.set({ name, value, ...options });
-          } catch (error) {
-            // The `set` method was called from a Server Component.
-            // This can be ignored if you have middleware refreshing user sessions.
-          }
-        },
-        remove(name: string, options: CookieOptions) {
-          try {
-            cookieStore.set({ name, value: "", ...options });
-          } catch (error) {
-            // The `delete` method was called from a Server Component.
-            // This can be ignored if you have middleware refreshing user sessions.
-          }
-        },
-      },
-    }
-  );
-}
 
 // This client is for server-side fetching of public data in Server Components.
-// It does not require cookies and is safe for read-only operations.
-export function createSupabaseServerClientReadOnly() {
+// It does not use cookies and is safe to be imported by any server component.
+export function createSupabaseServerClient() {
   return createClient(
     process.env.NEXT_PUBLIC_SUPABASE_URL!,
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
     {
-      // This is the key change
       auth: {
         persistSession: false,
       },


### PR DESCRIPTION
### Description

This PR completes the "Standup Notes" page by adding the "Past Notes" widget. It also introduces major feature enhancements, including the ability to edit notes from any date and a dynamic header that updates based on the current page. This release involved significant architectural refactoring to create a stable, client-rendered page that handles complex state interactions.

### Key Changes

*   **Past Notes Widget (`PastNotesList.tsx`)**:
    *   Created a new component to fetch and display a list of all past notes for the selected user.
    *   The list is sorted by date in descending order.
    *   Features "zebra striping" (alternating background colors) for improved readability.
    *   The widget is now a Client Component that fetches its own data and is triggered to refresh after a note is saved.

*   **Standup Form Enhancements**:
    *   The date field is now enabled, allowing users to select any date.
    *   Changing the date fetches the note for that specific day, allowing users to edit past entries.
    *   The form now correctly updates to show the latest saved data immediately after a save, without a page reload.

*   **Dynamic Page Header (`DashboardHeader.tsx`)**:
    *   The main dashboard header has been extracted into its own Client Component.
    *   It uses the `usePathname` hook to read the current URL and display a user-friendly title (e.g., "Standup Notes", "User List").

*   **Architectural Overhaul & Bug Fixes**:
    *   **Solved `searchParams` Error:** The Standup Notes page was completely refactored to be a static shell rendering a main Client Component (`StandupNotesView`). This component now handles all client-side state (user, note, date) and orchestrates its children, finally resolving a persistent and complex rendering bug.
    *   **State Management:** Implemented a robust "callback" system (`onNoteSaved`) and a `refreshKey` prop to allow the form to trigger a data re-fetch in the sibling `PastNotesList` component after a successful save.

### How to Test

1.  Pull down this branch locally and run `npm install`.
2.  Select a user and navigate to the "Standup Notes" page.
3.  **Test the Header:** Navigate to "User List", "Create User", and "Standup Notes". Verify the title in the header changes correctly for each page.
4.  **Test Past Notes Widget:** Verify the widget on the right loads and displays a list of previously saved notes for the user, sorted by date.
5.  **Test Date Editing:**
    *   In the "Daily Standup Note" form, select a past date from the date picker.
    *   The form should update to show the note data for that specific day (or be blank if none exists).
    *   Make an edit to a past note and click "Save Note".
6.  **Verify Data Sync:**
    *   Confirm that a "Success!" toast appears.
    *   Confirm that the "Past Notes" list on the right **immediately** updates to show the new content you just saved, without requiring a page reload.